### PR TITLE
I provided, use the client parameter in the SecurityFilter

### DIFF
--- a/src/main/java/org/pac4j/jee/filter/SecurityFilter.java
+++ b/src/main/java/org/pac4j/jee/filter/SecurityFilter.java
@@ -89,6 +89,12 @@ public class SecurityFilter extends AbstractConfigFilter {
         assertNotNull("config", config);
         final JEEContext context = new JEEContext(request, response, config.getSessionStore());
 
+        //get the client from the request parameter, this will allow a single filter to be used for multiple clients
+        String client = request.getParameter("client");
+        if(StringUtils.isNotBlank(client)){
+            clients = client;
+        }
+
         retrieveSecurityLogic().perform(context, config, (ctx, profiles, parameters) -> {
             // if no profiles are loaded, pac4j is not concerned with this request
             filterChain.doFilter(profiles.isEmpty() ? request : new Pac4JHttpServletRequestWrapper(request, profiles), response);


### PR DESCRIPTION
This allows to define a single securityFilter in web.xml to use for multiple saml idp for instance. Let's assume your filter protects the /saml servlet. Then by defining multiple saml configurations you can choose one like this https://foo.bar/saml?client=SAMLClient.2. 
This can be associated with better naming the clients for instance.