### PR TITLE
Migrate pac4j-jee to the latest version of  pac4j-core (4.0.0-RC3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>jee-pac4j</artifactId>
     <packaging>jar</packaging>
     <name>pac4j implementation for JEE</name>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <description>Security library for JEE based on pac4j</description>
     <url>https://github.com/pac4j/j2e-pac4j</url>
 
@@ -53,7 +53,7 @@
     </developers>
 
     <properties>
-        <pac4j.version>4.0.0-SNAPSHOT</pac4j.version>
+        <pac4j.version>4.0.0-RC3</pac4j.version>
         <java.version>1.8</java.version>
         <javaee.version>7.0</javaee.version>
     </properties>

--- a/src/main/java/org/pac4j/jee/config/ConfigSingleton.java
+++ b/src/main/java/org/pac4j/jee/config/ConfigSingleton.java
@@ -1,0 +1,23 @@
+package org.pac4j.jee.config;
+
+import org.pac4j.core.config.Config;
+
+/**
+ * A singleton of the configuration. Useful in implementations where the configuration must be
+ * shared and no dependency injection framework is available.
+ *
+ * @author Jerome Leleu
+ * @since 1.8.0
+ */
+public final class ConfigSingleton {
+
+  private static Config config = new Config();
+
+  public static Config getConfig() {
+    return config;
+  }
+
+  public static void setConfig(Config config) {
+    ConfigSingleton.config = config;
+  }
+}

--- a/src/main/java/org/pac4j/jee/filter/AbstractConfigFilter.java
+++ b/src/main/java/org/pac4j/jee/filter/AbstractConfigFilter.java
@@ -13,9 +13,9 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.pac4j.core.config.Config;
 import org.pac4j.core.config.ConfigBuilder;
-import org.pac4j.core.config.ConfigSingleton;
+import org.pac4j.jee.config.ConfigSingleton;
 import org.pac4j.core.context.JEEContext;
-import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.http.adapter.HttpActionAdapter;
 import org.pac4j.core.http.adapter.JEEHttpActionAdapter;

--- a/src/main/java/org/pac4j/jee/filter/CallbackFilter.java
+++ b/src/main/java/org/pac4j/jee/filter/CallbackFilter.java
@@ -10,7 +10,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.JEEContext;
-import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.engine.CallbackLogic;
 import org.pac4j.core.engine.DefaultCallbackLogic;
 

--- a/src/main/java/org/pac4j/jee/filter/LogoutFilter.java
+++ b/src/main/java/org/pac4j/jee/filter/LogoutFilter.java
@@ -2,7 +2,7 @@ package org.pac4j.jee.filter;
 
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.JEEContext;
-import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.engine.DefaultLogoutLogic;
 import org.pac4j.core.engine.LogoutLogic;
 

--- a/src/main/java/org/pac4j/jee/filter/SecurityFilter.java
+++ b/src/main/java/org/pac4j/jee/filter/SecurityFilter.java
@@ -12,6 +12,7 @@ import org.pac4j.core.config.Config;
 import org.pac4j.core.context.*;
 import org.pac4j.core.engine.DefaultSecurityLogic;
 import org.pac4j.core.engine.SecurityLogic;
+import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.jee.util.Pac4JHttpServletRequestWrapper;
 
 import static org.pac4j.core.util.CommonHelper.*;

--- a/src/main/java/org/pac4j/jee/util/Pac4jProducer.java
+++ b/src/main/java/org/pac4j/jee/util/Pac4jProducer.java
@@ -1,7 +1,7 @@
 package org.pac4j.jee.util;
 
 import org.pac4j.core.config.Config;
-import org.pac4j.core.config.ConfigSingleton;
+import org.pac4j.jee.config.ConfigSingleton;
 import org.pac4j.core.context.JEEContext;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.TechnicalException;


### PR DESCRIPTION
The goal of this PR is to be able to build a version of pac4-jee compliant with the latest version of pac4j-core (4.0.0-RC3)

I have fork the repository pac4j-jee and work on branch master 


Work done:
Retrieve ConfigSingleton class from previous version of pac4j-core and repackage this class into org.pac4j.jee.config
Addapt import of class Pac4jConstants