### PR TITLE
Fix lombok scope which is a compiletime only dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.32</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Lombok is a pure compiletime dependency and the final artifact should not depend on it.
Having a dependency brings it in needlessly and also causes IDEs to suggest using Lombok in own code, which is bad.
So as the Lombok documentation describes, the scope is changed to provided with this PR.
